### PR TITLE
docs(Backstage): connect modern-pastry-ffmpeg to Backstage catalog

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,14 @@
+# this is a catalog entity descriptor file for our Backstage instance (https://backstage.wistia.cloud)
+
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: Parse-Tool-Versions
+  description: Github action created to parse .tool-versions into the environment
+  annotations:
+    github.com/project-slug: wistia/parse-tool-versions
+    backstage.io/techdocs-ref: dir:.
+spec:
+  type: library
+  owner: app-platform
+  lifecycle: production

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -1,0 +1,10 @@
+# this file exists to generate techdocs for Backstage (https://backstage.wistia.cloud)
+
+site_name: Parse-Tool-Versions
+docs_dir: .
+plugins:
+  - techdocs-core
+  - same-dir
+  - exclude:
+      glob:
+        - node_modules/*


### PR DESCRIPTION
These files are required to connect modern-pastry-ffmpeg to our Backstage catalog (https://backstage.wistia.cloud).

- `catalog-info.yaml` contains configuration regarding repo description, team-ownership, repo tech stack, etc.

- `mkdocs.yaml` will allow discovery of documentation in this repo to be found via Backstage TechDocs