### PR TITLE
refactor: .tool-versions can include code comments so avoid trying to env-varify those

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,11 +26,12 @@ runs:
         shell: bash
         run: |
           while IFS= read -r line; do
-            NAME="$(echo $line | cut -d' ' -f1)${{inputs.postfix}}"
-            if [ "${{inputs.uppercase}}" == "true" ]; then NAME="$(echo $NAME | tr [:lower:] [:upper:])"; fi
-            
-            VALUE=$(echo $line | cut -d' ' -f2-)
+            if [[ $line != \#* ]]; then
+              NAME="$(echo $line | cut -d' ' -f1)${{inputs.postfix}}"
+              if [ "${{inputs.uppercase}}" == "true" ]; then NAME="$(echo $NAME | tr [:lower:] [:upper:])"; fi
 
-            echo "$NAME=$VALUE" >> $GITHUB_ENV
+              VALUE=$(echo $line | cut -d' ' -f2-)
+
+              echo "$NAME=$VALUE" >> $GITHUB_ENV
+            fi
           done < ${{inputs.filename}}
-  


### PR DESCRIPTION
in another repo I had a `.tool-versions` file that looked like this:

```
nodejs 18.18.1
# in v2.x, Yarn introduced its own version manager which can only be configured on a per-project basis.
# this actual version used is set in package.json#packageManager & .yarnrc.yml
yarn 1.22.19
```

and in that repo, this action produced the following ENV VARs:
```
NODEJS_TOOL_VERSION: 18.18.1
#_TOOL_VERSION: this actual version used is set in package.json#packageManager & .yarnrc.yml
YARN_TOOL_VERSION: 1.22.19
```

this change just updates the bash script to skip lines that begin with a leading `#`