### PR TITLE
refactor: extract inlined shell script in action to own file

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,21 @@
+name: Shellcheck
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@cd81f4475ab741e097ec0fe73b692f3e49d66b8c # v2.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: Test
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+    runs-on: ubuntu-20.04
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+
+      - name: Setup BATS
+        uses: mig4/setup-bats@2859ea733ef81b6ba31008a7fba0cacfbf2a5429 # v1.2.0
+        with:
+          bats-version: 1.10.0
+
+      - name: Run tests
+        run: bats -r ./test/parse_tool_versions_test.bats

--- a/README.md
+++ b/README.md
@@ -4,18 +4,18 @@ Github action that parses .tool-versions into the environment.
 ## Usage
 
 ```
-      - name: Parse .tool-versions
-        uses: wistia/parse-tool-versions@v2.0.0
-        with:
-          filename: '.tool-versions'
-          uppercase: 'true'
-          prefix: 'tool_version_'
+  - name: Parse .tool-versions
+    uses: wistia/parse-tool-versions@v2.0.0
+    with:
+      filename: '.tool-versions'
+      uppercase: 'true'
+      prefix: 'tool_version_'
 
-      # Sometime later in the same job...
-      - name: Set up Node.js environment
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ env.TOOL_VERSION_NODEJS }}
+  # Sometime later in the same job...
+  - name: Set up Node.js environment
+    uses: actions/setup-node@v3
+    with:
+      node-version: ${{ env.TOOL_VERSION_NODEJS }}
 ```
 
 This command reads `.tool-versions` (or an alternate text file provided in `filename` input), ignores comments with leading `#` and outputs each tool name (with or without optional prefix/postfix) into `GITHUB_ENV`. All inputs are optional; by default, tool names & prefix/postfix are uppercased.
@@ -37,3 +37,27 @@ Use to control what is prepended to the tool name (eg. `tool_version_` w/ ruby w
 ### Postfix
 
 Use to control what is appended to the tool name (eg. `_tool_version` w/ ruby would emit `RUBY_TOOL_VERSION`)
+
+## Development
+
+### Running locally
+
+```
+env FILENAME=.tool-versions-test UPPERCASE=true PREFIX=TOOL_VERSIONS_ POSTFIX=_TOOL_VERSIONS bash parse_tool_versions.sh
+```
+
+### Tests
+
+#### Requirements
+
+Install [Bats-core: Bash Automated Testing System](https://bats-core.readthedocs.io/en/stable/)
+
+```
+brew install bats
+```
+
+#### Run tests
+
+```
+bats test/parse_tool_versions_test.bats
+```

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Github action that parses .tool-versions into the environment.
       - name: Parse .tool-versions
         uses: wistia/parse-tool-versions@v2.0.0
         with:
+          filename: '.tool-versions'
           uppercase: 'true'
           prefix: 'tool_version_'
-          filename: '.tool-versions'
 
       # Sometime later in the same job...
       - name: Set up Node.js environment
@@ -22,18 +22,18 @@ This command reads `.tool-versions` (or an alternate text file provided in `file
 
 ## Inputs
 
+### Filename
+
+The filename to read from; this can be a path
+
 ### Uppercase
 
-set this to any string besides 'true' to use `snake_case` instead of `MACRO_CASE`
+Set to 'false' to use `snake_case` instead of `MACRO_CASE`
 
 ### Prefix
 
-use to control what is prepended to the tool name (eg. `tool_version_` w/ ruby would emit `TOOL_VERSION_RUBY`)
+Use to control what is prepended to the tool name (eg. `tool_version_` w/ ruby would emit `TOOL_VERSION_RUBY`)
 
 ### Postfix
 
-use to control what is appended to the tool name (eg. `_tool_version` w/ ruby would emit `RUBY_TOOL_VERSION`)
-
-### Filename
-
-The filename read from; this can be a path
+Use to control what is appended to the tool name (eg. `_tool_version` w/ ruby would emit `RUBY_TOOL_VERSION`)

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,10 @@
 name: 'Parse .tool-versions'
 description: 'Parse .tool-versions file, setting versions in env variables'
 inputs:
+  filename:
+    description: ".tool-versions filename. default is `.tool-versions`"
+    required: false
+    default: '.tool-versions'
   uppercase:
     description: "should the variables be uppercase?"
     required: false
@@ -11,34 +15,16 @@ inputs:
   postfix:
     description: "postfix applied after the tool version name (eg. _tool_version)"
     required: false
-  filename:
-    description: ".tool-versions filename. default is `.tool-versions`"
-    required: false
-    default: '.tool-versions'
 
 branding:
   icon: list
   color: purple
 
 runs:
-    using: "composite"
-    steps:
-      - name: Retrieve version
-        id: version
-        shell: bash
-        run: |
-          while IFS= read -r line; do
-            if [[ $line != \#* ]]; then
-              NAME="$(echo $line | cut -d' ' -f1)"
-              if [ -n "${{inputs.prefix}}" ]; then
-                NAME="${{inputs.prefix}}$NAME"
-              elif [ -n "${{inputs.postfix}}" ]; then
-                NAME="$NAME${{inputs.postfix}}"
-              fi
-              if [ "${{inputs.uppercase}}" == "true" ]; then NAME="$(echo $NAME | tr [:lower:] [:upper:])"; fi
-
-              VALUE=$(echo $line | cut -d' ' -f2-)
-
-              echo "${NAME/-/_}=$VALUE" >> $GITHUB_ENV
-            fi
-          done < ${{inputs.filename}}
+  using: "composite"
+  steps:
+    - name: Retrieve version
+      id: version
+      shell: bash
+      run: |
+        env FILENAME=${{ inputs.filename }} UPPERCASE=${{ inputs.uppercase }} PREFIX=${{ inputs.prefix }} POSTFIX=${{ inputs.postfix }} bash ${GITHUB_ACTION_PATH}/parse_tool_versions.sh >> $GITHUB_ENV

--- a/parse_tool_versions.sh
+++ b/parse_tool_versions.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+while IFS= read -r line; do
+  if [[ $line != \#* ]]; then
+    NAME="$(echo "$line" | cut -d' ' -f1)"
+    if [ -n "$PREFIX" ]; then
+      NAME="$PREFIX$NAME"
+    elif [ -n "$POSTFIX" ]; then
+      NAME="$NAME$POSTFIX"
+    fi
+    if [ "$UPPERCASE" == "true" ]; then NAME="$(echo "$NAME" | tr "[:lower:]" "[:upper:]")"; fi
+
+    VALUE=$(echo "$line" | cut -d' ' -f2-)
+
+    echo "${NAME/-/_}=$VALUE"
+  fi
+done < "$FILENAME"

--- a/test/parse_tool_versions_test.bats
+++ b/test/parse_tool_versions_test.bats
@@ -1,0 +1,55 @@
+#!/usr/bin/env bats
+
+@test "Test parse_tool_versions.sh" {
+  # temporary .tool-versions file with some typical values
+  echo "nodejs 20.9.0" > .tool-versions
+  echo "ruby 3.2.3" >> .tool-versions
+  echo "gitlabci-lint 1.12.0" >> .tool-versions
+
+  # temporary second .tool-versions file with an alternate name
+  echo "python 3.12.1" >> .another-tool-versions-file
+
+  # test default inputs (these are set in action.yml)
+  run env FILENAME=.tool-versions UPPERCASE=true bash parse_tool_versions.sh
+  [ "$status" -eq 0 ]
+  [[ "${lines[0]}" == "NODEJS=20.9.0" ]]
+  [[ "${lines[1]}" == "RUBY=3.2.3" ]]
+  [[ "${lines[2]}" == "GITLABCI_LINT=1.12.0" ]]
+
+  # test alternate file name
+  run env FILENAME=.another-tool-versions-file UPPERCASE=true bash parse_tool_versions.sh
+  [ "$status" -eq 0 ]
+  [[ "${lines[0]}" == "PYTHON=3.12.1" ]]
+
+  # test uppercase false
+  run env FILENAME=.tool-versions UPPERCASE=false bash parse_tool_versions.sh
+  [ "$status" -eq 0 ]
+  [[ "${lines[0]}" == "nodejs=20.9.0" ]]
+  [[ "${lines[1]}" == "ruby=3.2.3" ]]
+  [[ "${lines[2]}" == "gitlabci_lint=1.12.0" ]]
+
+  # test prefix
+  run env FILENAME=.tool-versions UPPERCASE=true PREFIX=TOOL_VERSION_ bash parse_tool_versions.sh
+  [ "$status" -eq 0 ]
+  [[ "${lines[0]}" == "TOOL_VERSION_NODEJS=20.9.0" ]]
+  [[ "${lines[1]}" == "TOOL_VERSION_RUBY=3.2.3" ]]
+  [[ "${lines[2]}" == "TOOL_VERSION_GITLABCI_LINT=1.12.0" ]]
+
+  # test postfix
+  run env FILENAME=.tool-versions UPPERCASE=true POSTFIX=_TOOL_VERSION bash parse_tool_versions.sh
+  [ "$status" -eq 0 ]
+  [[ "${lines[0]}" == "NODEJS_TOOL_VERSION=20.9.0" ]]
+  [[ "${lines[1]}" == "RUBY_TOOL_VERSION=3.2.3" ]]
+  [[ "${lines[2]}" == "GITLABCI_LINT_TOOL_VERSION=1.12.0" ]]
+
+  # test both prefix & postfix being set (only prefix should be used)
+  run env FILENAME=.tool-versions UPPERCASE=true PREFIX=TOOL_VERSION_ POSTFIX=_TOOL_VERSION bash parse_tool_versions.sh
+  [ "$status" -eq 0 ]
+  [[ "${lines[0]}" == "TOOL_VERSION_NODEJS=20.9.0" ]]
+  [[ "${lines[1]}" == "TOOL_VERSION_RUBY=3.2.3" ]]
+  [[ "${lines[2]}" == "TOOL_VERSION_GITLABCI_LINT=1.12.0" ]]
+
+  # cleanup
+  rm .tool-versions
+  rm .another-tool-versions-file
+}


### PR DESCRIPTION
I tried a couple other things before going with environment variables to pass args into the shell script.

using positional arguments didn't work because in order for the postfix to work, the prefix can't be set and passing an empty string didn't work, so whatever was set for the postfix argument would end up as the prefix.

I tried using single char flags (ie. `-f` for filename) like this:
```
bash ${GITHUB_ACTION_PATH}/parse_tool_versions.sh -f ${{ inputs.filename }} -u ${{ inputs.uppercase }} -p ${{ inputs.prefix }} -x ${{ inputs.postfix }} >> $GITHUB_ENV
```
and in the script:
```
+while getopts "f:u:p:x" option; do
+case "$option" in
+f) filename=${OPTARG};;
+u) uppercase=${OPTARG};;
+p) prefix=${OPTARG};;
+x) postfix=${OPTARG};;
+*) echo "Invalid option";;
+esac
+done
```
but faced the same problem... if `inputs.prefix` was unset, `-x` would end up being the value passed into `-p` and so you'd end up with `_X_NODEJS` etc. 

there's probably something better than environment variables but this works