### PR TITLE
Fix shell variable interpolation for prefix/postfix

### DIFF
--- a/parse_tool_versions.sh
+++ b/parse_tool_versions.sh
@@ -4,9 +4,9 @@ while IFS= read -r line; do
   if [[ $line != \#* ]]; then
     NAME="$(echo "$line" | cut -d' ' -f1)"
     if [ -n "$PREFIX" ]; then
-      NAME="$PREFIX$NAME"
+      NAME="${PREFIX}${NAME}"
     elif [ -n "$POSTFIX" ]; then
-      NAME="$NAME$POSTFIX"
+      NAME="${NAME}${POSTFIX}"
     fi
     if [ "$UPPERCASE" == "true" ]; then NAME="$(echo "$NAME" | tr "[:lower:]" "[:upper:]")"; fi
 


### PR DESCRIPTION
When prefix or postfix is used, shell variable interpolation fails and ends up blanking the name, causing an error in Github Actions.  This PR adds explicit braces around the shell variables.